### PR TITLE
feat: 경로 따라그리기 및 컴포넌트별 통신로직 구축 1차 마무리

### DIFF
--- a/runnerpia/Views/Main/Route/RouteRecordView.swift
+++ b/runnerpia/Views/Main/Route/RouteRecordView.swift
@@ -13,6 +13,8 @@ class RouteRecordView: UIView {
     
     // MARK: Properties
     let locationManager = CLLocationManager()
+    let pathOverlay = NMFPath()
+    var pathCoordinates:[NMGLatLng] = []
     
     let map: NMFMapView = {
         let map = NMFMapView()
@@ -463,11 +465,18 @@ extension RouteRecordView: CLLocationManagerDelegate{
             }
             
             let meterString = Int(accumulatedMeter / 10) == 0 ? "0\(accumulatedMeter)" : "\(accumulatedMeter)"
-            let kilometerString = Int(accumulatedKilometer / 10) == 0 ? "0\(accumulatedKilometer)" : "\(accumulatedKilometer)"
+            let kilometerString = "\(accumulatedKilometer)"
             
             elapsedDistanceLabel.text = "\(kilometerString):\(meterString)km"
             
             previousLocation = locationManager.location
+            pathCoordinates.append(NMGLatLng(lat: locationManager.location!.coordinate.latitude, lng: locationManager.location!.coordinate.longitude))
+        
+            pathOverlay.path = NMGLineString(points: pathCoordinates)
+            pathOverlay.color = hexStringToUIColor(hex: "#21A345")
+            pathOverlay.outlineColor = .clear
+            pathOverlay.width = 10
+            pathOverlay.mapView = map
         }
         
         

--- a/runnerpia/Views/Main/Route/RouteRecordView.swift
+++ b/runnerpia/Views/Main/Route/RouteRecordView.swift
@@ -151,11 +151,18 @@ class RouteRecordView: UIView {
     var timer = Timer()
     
     var pushTime: TimeInterval = 0
+    var elapsedSeconds: TimeInterval = 0
+    var elapsedMinutes: TimeInterval = 0
     
     var feedbackGenerator: UINotificationFeedbackGenerator?
     
     var isRecordPaused: Bool?
     var isRecordStarted: Bool = false
+    
+    var previousLocation: CLLocation?
+    var accumulatedDistance = 0
+    var accumulatedMeter = 0
+    var accumulatedKilometer = 0
     
     // MARK: - LifeCycles
     override init(frame: CGRect) {
@@ -199,14 +206,19 @@ class RouteRecordView: UIView {
             self.feedbackGenerator?.notificationOccurred(.success)
             playButton.removeTarget(nil, action: nil, for: .allEvents)
             setupRecordingUI()
+            
             isRecordStarted = true
             pushTime = 0
+            
+            timer.invalidate()
+            timer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(updateElapsedLabels), userInfo: nil, repeats: true)
         }else if(pushTime == 2 && isRecordStarted){
             self.feedbackGenerator?.notificationOccurred(.success)
             print("record stop...")
         }
     }
     
+    // 레코드 이후 두개로 쪼개진 재생 - 멈춤버튼 중 재생버튼에 해당되는 부분
     @objc func playButtonDuringRecordTouchUpHandler(){
         isRecordPaused = false
         
@@ -214,8 +226,11 @@ class RouteRecordView: UIView {
         stopButton.isHidden = true
         
         playButton.isHidden = false
+        
+        timer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(updateElapsedLabels), userInfo: nil, repeats: true)
     }
     
+    // 기존 플레이버튼이 레코드 상태에 따라 다른 역할을 하게되었을때 호출되는 셀렉터 함수
     @objc func playButtonTouchUpHandlerDuringRecord(){
         guard let isPaused = self.isRecordPaused else {
             self.isRecordPaused = false
@@ -229,6 +244,8 @@ class RouteRecordView: UIView {
             
             self.playButtonDuringRecord.isHidden = false
             self.stopButton.isHidden = false
+            
+            timer.invalidate()
         }else{
             self.playButton.isHidden = false
             
@@ -246,6 +263,23 @@ class RouteRecordView: UIView {
         timer.fire()
 
         animateButton(isReset: false)
+    }
+    
+    // 누적 시간 및 이동거리 계산 셀렉터 함수 - 내부에서 레이블 업데이트 로직과 거리 업데이트 로직이 함께 실행됨
+    @objc func updateElapsedLabels(){
+        // MARK: 시간 레이블 업데이트
+        let elapsedTimeLabel = elapsedTimeSection.subviews.first as! UILabel
+        elapsedSeconds += 1
+        
+        if(elapsedSeconds >= 60){
+            elapsedMinutes += 1
+            elapsedSeconds = 0
+        }
+        
+        let minuteString = Int(elapsedMinutes / 10) == 0 ? "0\(Int(elapsedMinutes))" : "\(Int(elapsedMinutes))"
+        let secondString = Int(elapsedSeconds / 10) == 0 ? "0\(Int(elapsedSeconds))" : "\(Int(elapsedSeconds))"
+        
+        elapsedTimeLabel.text = "\(minuteString):\(secondString)"
     }
     
     // MARK: Helpers
@@ -399,5 +433,28 @@ extension RouteRecordView: CLLocationManagerDelegate{
         let cameraUpdate = NMFCameraUpdate(scrollTo: NMGLatLng(lat: locations.first!.coordinate.latitude, lng: locations.first!.coordinate.longitude))
         map.moveCamera(cameraUpdate)
         
+        // MARK: 거리 레이블 업데이트
+        let elapsedDistanceLabel = movedDistanceSection.subviews.first as! UILabel
+        guard let previous = previousLocation else {
+            previousLocation = locationManager.location
+            return
+        }
+        accumulatedDistance += Int(locationManager.location!.distance(from: previous))
+        
+        if(accumulatedDistance / 10 >= 1){
+            accumulatedMeter += 1
+            accumulatedDistance = accumulatedDistance % 10
+        }
+        if(accumulatedMeter / 100 >= 1){
+            accumulatedKilometer += 1
+            accumulatedMeter = 0
+        }
+        
+        let meterString = Int(accumulatedMeter / 10) == 0 ? "0\(accumulatedMeter)" : "\(accumulatedMeter)"
+        let kilometerString = Int(accumulatedKilometer / 10) == 0 ? "0\(accumulatedKilometer)" : "\(accumulatedKilometer)"
+        
+        elapsedDistanceLabel.text = "\(kilometerString):\(meterString)km"
+        
+        previousLocation = locationManager.location
     }
 }


### PR DESCRIPTION
경로그리기 기능 1차 마무리 진행하였습니다 👍  컴포넌트별 사용자 상호작용에 따른 통신 로직을 정리합니다.

![스크린샷 2023-05-16 오전 8 31 00](https://github.com/Parkjju/runnerpia/assets/75518683/ca36f468-b4b2-4d7c-a0e8-0ce5a03be6c5)
1. 플레이버튼에 등록된 셀렉터는 `@objc playButtonTouchUpHandler`, `@objc playButtonTouchDownHandler`입니다.
2. `playButtonTouchUpHandler`는 2초 이상 버튼을 누르지 않았을때 누르고 있던 시간 `pushTime` 속성값을 0초로 초기화해줍니다.
3. `playButtonTouchDownHandler`는 버튼을 누르고 있는 동안 타이머가 시작되어 `@objc addSecondToPushTime` 셀렉터를 1초마다 호출합니다.
[(소스코드)](https://github.com/Parkjju/runnerpia/blob/05bb7a6d3b56ad40e00b1b47eee6ba4b45c985ae/runnerpia/Views/Main/Route/RouteRecordView.swift#L184-L221)


https://github.com/Parkjju/runnerpia/assets/75518683/8f7f5607-a559-4a40-93ae-ec785cd20fde
1. 재생버튼 2초이상 클릭으로 트래킹이 본격적으로 시작된 이후부터는 트래킹 여부를 `isRecordStarted`와 `isRecordPaused`속성들로 관리합니다.
2. 기존에 파란색 재생버튼 역할을 하던 인스턴스의 셀렉터들을 모두 지운 뒤 새로운 역할의 셀렉터를 부여하게 됩니다. -> 같은 버튼 인스턴스이지만 회색 일시정지 버튼으로 UI교체와 함께 `playButtonTouchUpHandlerDuringRecord` 셀렉터를 부여하게 됨 [(소스코드)](https://github.com/Parkjju/runnerpia/blob/05bb7a6d3b56ad40e00b1b47eee6ba4b45c985ae/runnerpia/Views/Main/Route/RouteRecordView.swift#L386-L390)
3. `playButtonTouchUpHandlerDuringRecord` 셀렉터는 주석에도 있듯 트래킹 시작 이후 역할이 달라진 재생버튼에 새로 부여된 역할입니다. 트래킹을 일시정지하여 타이머를 비활성화합니다. 
4. `playButtonTouchUpHandlerDuringRecord` 셀렉터 호출시 일시정지 버튼은 `isHidden`으로 숨겨지고, 오토레이아웃 상에만 등록되어 있던 `playButtonDuringRecord`, `stopButton` 인스턴스의 `isHidden = false`로 세팅되어 UI에 등장합니다. [(소스코드)](https://github.com/Parkjju/runnerpia/blob/05bb7a6d3b56ad40e00b1b47eee6ba4b45c985ae/runnerpia/Views/Main/Route/RouteRecordView.swift#L236-L257)
5. 재생버튼은 `playButtonDuringRecordTouchUpHandler`, 멈춤버튼은 `stopButtonTouchUpHandler` 셀렉터를 등록합니다. `playButtonDuringTouchUpHandler`는 `isRecordPaused` 속성에 따라 트래킹을 재시작 할지 여부를 선택하고, `stopButtonTouchUpHandler`는 2초 이상 정지버튼을 누르고 있는 경우 트래킹을 완전히 종료하도록 추후 로직 설계 예정입니다. [(playButtonDuringRecordTouchUpHandler)](https://github.com/Parkjju/runnerpia/blob/05bb7a6d3b56ad40e00b1b47eee6ba4b45c985ae/runnerpia/Views/Main/Route/RouteRecordView.swift#L224-L233), [(stopButtonTouchUpHandler)](https://github.com/Parkjju/runnerpia/blob/05bb7a6d3b56ad40e00b1b47eee6ba4b45c985ae/runnerpia/Views/Main/Route/RouteRecordView.swift#L259-L268)
6. 각종 좌표 변화감지에 따른 폴리라인 그리기와 네이버맵 카메라 이동 로직은 `CLLocationManagerDelegate` 프로토콜 함수 내에 정의되어 있습니다.[(소스코드)](https://github.com/Parkjju/runnerpia/blob/05bb7a6d3b56ad40e00b1b47eee6ba4b45c985ae/runnerpia/Views/Main/Route/RouteRecordView.swift#L433-L484)

