### PR TITLE
feat: API configuration / Alamofire 기본설정 및 enum타입 추가

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -5,6 +5,7 @@ target 'runnerpia' do
   # Comment the next line if you don't want to use dynamic frameworks
   use_frameworks!
   pod 'NMapsMap'
+  pod 'Alamofire'
 
   # Pods for runnerpia
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,20 +1,24 @@
 PODS:
+  - Alamofire (5.7.1)
   - NMapsGeometry (1.0.1)
   - NMapsMap (3.16.2):
     - NMapsGeometry
 
 DEPENDENCIES:
+  - Alamofire
   - NMapsMap
 
 SPEC REPOS:
   trunk:
+    - Alamofire
     - NMapsGeometry
     - NMapsMap
 
 SPEC CHECKSUMS:
+  Alamofire: 0123a34370cb170936ae79a8df46cc62b2edeb88
   NMapsGeometry: 53c573ead66466681cf123f99f698dc8071a4b83
   NMapsMap: aaa64717249b06ae82c3a3addb3a01f0e33100ab
 
-PODFILE CHECKSUM: 40b440cf6b857a4e8ef095648f0112e05757dbbf
+PODFILE CHECKSUM: 26a548e4da2a838ba6fbf566886bd7c9c2238fd4
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.12.0

--- a/runnerpia.xcodeproj/project.pbxproj
+++ b/runnerpia.xcodeproj/project.pbxproj
@@ -61,6 +61,8 @@
 		C8AE07E82A2E06CA009C1CFD /* HalfSizePresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8AE07E72A2E06CA009C1CFD /* HalfSizePresentationController.swift */; };
 		C8F833C92A24B17500ED146A /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F833C82A24B17500ED146A /* SearchViewController.swift */; };
 		C8F833CC2A24B1C600ED146A /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F833CB2A24B1C600ED146A /* SearchView.swift */; };
+		C95C30682A381A2000724002 /* APIRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95C30672A381A2000724002 /* APIRouter.swift */; };
+		C95C306A2A381FED00724002 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95C30692A381FED00724002 /* Constants.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -119,6 +121,8 @@
 		C8AE07E72A2E06CA009C1CFD /* HalfSizePresentationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HalfSizePresentationController.swift; sourceTree = "<group>"; };
 		C8F833C82A24B17500ED146A /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
 		C8F833CB2A24B1C600ED146A /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
+		C95C30672A381A2000724002 /* APIRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIRouter.swift; sourceTree = "<group>"; };
+		C95C30692A381FED00724002 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		FD26A4388A2F477280BCBFA7 /* Pods_runnerpia.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_runnerpia.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FFC1BDC7FCC4682C38EED567 /* Pods-runnerpia.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-runnerpia.release.xcconfig"; path = "Target Support Files/Pods-runnerpia/Pods-runnerpia.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -221,6 +225,7 @@
 			children = (
 				88C189DB2A02985900A240BD /* AppDelegate.swift */,
 				88C189DD2A02985A00A240BD /* SceneDelegate.swift */,
+				C95C30662A381A0D00724002 /* Network */,
 				C847CC932A1E43CD00F0639C /* Util */,
 				88C189F12A0298EC00A240BD /* Models */,
 				88C189F02A0298E500A240BD /* Views */,
@@ -297,6 +302,7 @@
 				C847CC942A1E43CD00F0639C /* Constraints.swift */,
 				C847CC952A1E43CD00F0639C /* LeftAlignedCollectionViewFlowLayout.swift */,
 				C847CC962A1E43CD00F0639C /* Tags.swift */,
+				C95C30692A381FED00724002 /* Constants.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -413,6 +419,14 @@
 				C8A684502A2A1F4B00698DA9 /* HalfModalView.swift */,
 			);
 			path = Search;
+			sourceTree = "<group>";
+		};
+		C95C30662A381A0D00724002 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				C95C30672A381A2000724002 /* APIRouter.swift */,
+			);
+			path = Network;
 			sourceTree = "<group>";
 		};
 		C9AD727D2A10675E005B9B5B /* Main */ = {
@@ -571,6 +585,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C8F833C92A24B17500ED146A /* SearchViewController.swift in Sources */,
+				C95C30682A381A2000724002 /* APIRouter.swift in Sources */,
 				88566E362A2F2D56000833A1 /* PostDetailViewController.swift in Sources */,
 				C86646BE2A10BD8C00A4E12A /* MypageViewController.swift in Sources */,
 				C86646B52A10BBB100A4E12A /* HomeViewController.swift in Sources */,
@@ -604,6 +619,7 @@
 				88B7560A2A31E22000B701C6 /* ReviewDetailViewController.swift in Sources */,
 				88C189DE2A02985A00A240BD /* SceneDelegate.swift in Sources */,
 				C847CC922A1E43BF00F0639C /* UIView.swift in Sources */,
+				C95C306A2A381FED00724002 /* Constants.swift in Sources */,
 				C886B9122A1B8933006BE2CD /* ParticularView.swift in Sources */,
 				884F6DEE2A120A6E007B7F73 /* UIImage.swift in Sources */,
 				C847CC982A1E43CD00F0639C /* LeftAlignedCollectionViewFlowLayout.swift in Sources */,
@@ -766,7 +782,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = C52UTF3KCV;
+				DEVELOPMENT_TEAM = 5JQS3FU5R6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = runnerpia/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -799,7 +815,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = C52UTF3KCV;
+				DEVELOPMENT_TEAM = 5JQS3FU5R6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = runnerpia/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/runnerpia/Network/APIRouter.swift
+++ b/runnerpia/Network/APIRouter.swift
@@ -1,0 +1,132 @@
+//
+//  APIRouter.swift
+//  runnerpia
+//
+//  Created by 박경준 on 2023/06/13.
+//
+
+import Foundation
+import Alamofire
+
+protocol APIConfiguration: URLRequestConvertible {
+    var method: HTTPMethod { get }
+    var path: String { get }
+    var parameters: Parameters? { get }
+}
+
+// MARK: UserEndpoint
+enum UserEndPoint: APIConfiguration{
+    
+    // MARK: 유저 관련 메서드
+    case kakaoLogin
+    case logout(accessToken: String)
+    case checkDuplicateID(id: String)
+    case checkDuplicateNickname(nickname: String)
+    
+    // MARK: 북마크 관련 메서드
+    case getAllBookmark(accessToken: String)
+    case createBookmark(accessToken: String)
+    case deleteBookmark(accessToken: String, bookmarkId: Int)
+    
+    // MARK: 추천경로 관련 메서드
+    case getNumberOfUsingRecommendedRoute(accessToken: String)
+    case increaseNumberOfUsingRecommendedRoute(accessToken: String)
+    
+    
+    var method: HTTPMethod{
+        switch self{
+        case .kakaoLogin:
+            return .post
+        case .logout:
+            return .get
+        case .checkDuplicateID:
+            return .get
+        case .checkDuplicateNickname:
+            return .get
+        case .getAllBookmark:
+            return .get
+        case .createBookmark:
+            return .post
+        case .deleteBookmark:
+            return .post
+        case .getNumberOfUsingRecommendedRoute:
+            return .get
+        case .increaseNumberOfUsingRecommendedRoute:
+            return .get
+        }
+    }
+    
+    var path: String{
+        switch self{
+        case .kakaoLogin:
+            return "/auth/kakao"
+        case .logout:
+            return "/auth/logout"
+        case .checkDuplicateID(let id):
+            return "/user/checkId/\(id)"
+        case .checkDuplicateNickname(let nickname):
+            return "/user/checkNickname/\(nickname)"
+        case .getAllBookmark:
+            return "/user/bookmark/getAll"
+        case .createBookmark:
+            return "/user/bookmark/create"
+        case .deleteBookmark:
+            return "/user/bookmark/delete"
+        case .getNumberOfUsingRecommendedRoute:
+            return "/user/getUseRecommended"
+        case .increaseNumberOfUsingRecommendedRoute:
+            return "/user/increaseUseRecommended"
+        }
+    }
+    
+    var parameters: Alamofire.Parameters?{
+        switch self{
+        case .kakaoLogin:
+            return nil
+        case .logout(let accessToken):
+            return [K.APIParameterKey.accessToken: accessToken]
+        case .checkDuplicateID(let id):
+            return [K.APIParameterKey.id: id]
+        case .checkDuplicateNickname(let nickname):
+            return [K.APIParameterKey.nickname: nickname]
+        case .getAllBookmark(let accessToken):
+            return [K.APIParameterKey.accessToken: accessToken]
+        case .createBookmark(let accessToken):
+            return [K.APIParameterKey.accessToken: accessToken]
+        case .deleteBookmark(let accessToken, let id):
+            return [K.APIParameterKey.accessToken: accessToken, K.APIParameterKey.id: id]
+        case .getNumberOfUsingRecommendedRoute(let accessToken):
+            return [K.APIParameterKey.accessToken: accessToken]
+        case .increaseNumberOfUsingRecommendedRoute(let accessToken):
+            return [K.APIParameterKey.accessToken: accessToken]
+        }
+    }
+    
+    func asURLRequest() throws -> URLRequest {
+        let url = try K.ProductionServer.baseURL.asURL()
+        
+        var urlRequest = URLRequest(url: url.appendingPathComponent(path))
+        
+        // HTTP Method
+        urlRequest.httpMethod = method.rawValue
+        
+        // Common Headers
+        urlRequest.setValue(ContentType.json.rawValue, forHTTPHeaderField: HTTPHeaderField.acceptType.rawValue)
+        urlRequest.setValue(ContentType.json.rawValue, forHTTPHeaderField: HTTPHeaderField.contentType.rawValue)
+ 
+        // Parameters
+        if let parameters = parameters {
+            do {
+                urlRequest.httpBody = try JSONSerialization.data(withJSONObject: parameters, options: [])
+            } catch {
+                throw AFError.parameterEncodingFailed(reason: .jsonEncodingFailed(error: error))
+            }
+        }
+        
+        return urlRequest
+    }
+    
+    
+}
+
+// MARK: RouteEndpoint

--- a/runnerpia/Network/APIRouter.swift
+++ b/runnerpia/Network/APIRouter.swift
@@ -130,3 +130,88 @@ enum UserEndPoint: APIConfiguration{
 }
 
 // MARK: RouteEndpoint
+enum RouteEndPoint: APIConfiguration{
+    case postRoute(accessToken: String, route: Route)
+    case getRoute(accessToken: String, id: Int)
+    case getReview(accessToken: String, id: Int)
+    case modifyRoute(accessToken: String, id: Int)
+    case deleteRoute(accessToken: String, id: Int)
+    case checkIsRun(accessToken: String, id: Int)
+    case getAllRoute(accessToken: String)
+    case getAllReview(accessToken: String)
+    case getRouteFromCoordinate(accessToken: String, longitude: CGFloat, latitude: CGFloat)
+    case getRouteFromCityName(accessToken: String, city: String, state: String)
+    case checkRouteNameIsDuplicated(accessToken: String, routeName: String)
+    case getRecommendedRouteFromCoordinate(accessToken: String, longitude: CGFloat, latitude: CGFloat)
+    case getPopularTags(accessToken: String)
+    
+    var method: Alamofire.HTTPMethod{
+        switch self{
+        case .postRoute:
+            return .post
+        case .getRoute:
+            return .get
+        case .getReview:
+            return .get
+        case .modifyRoute:
+            return .put
+        case .deleteRoute:
+            return .delete
+        case .checkIsRun:
+            return .get
+        case .getAllRoute:
+            return .get
+        case .getAllReview:
+            return .get
+        case .getRouteFromCoordinate:
+            return .get
+        case .getRouteFromCityName:
+            return .get
+        case .checkRouteNameIsDuplicated:
+            return .get
+        case .getRecommendedRouteFromCoordinate:
+            return .get
+        case .getPopularTags:
+            return .get
+        }
+    }
+    
+    var path: String{
+        switch self{
+        case .postRoute:
+            return "/running-route"
+        case .getRoute(let accessToken, let id):
+            return "/running-route/main/\(id)"
+        case .getReview(let accessToken, let id):
+            return "/running-route/sub/\(id)"
+        case .modifyRoute(let accessToken, let id):
+            return "/running-route/\(id)"
+        case .deleteRoute(let accessToken, let id):
+            return "/running-route/\(id)"
+        case .checkIsRun(let accessToken, let id):
+            return "/running-route/checkRunningExperience/\(id)"
+        case .getAllRoute:
+            return "/running-route/allMainRoute"
+        case .getAllReview:
+            return "/running-route/allSubRoute"
+        case .getRouteFromCoordinate(let accessToken, let longitude, let latitude):
+            return "/running-route/searchLocation?latitude=\(latitude)&longitude=\(longitude)"
+        case .getRouteFromCityName:
+            return .get
+        case .checkRouteNameIsDuplicated:
+            return .get
+        case .getRecommendedRouteFromCoordinate:
+            return .get
+        case .getPopularTags:
+            return .get
+        }
+    }
+    
+    var parameters: Alamofire.Parameters?
+    
+    func asURLRequest() throws -> URLRequest {
+        <#code#>
+    }
+    
+    
+}

--- a/runnerpia/Util/Constants.swift
+++ b/runnerpia/Util/Constants.swift
@@ -1,0 +1,67 @@
+//
+//  Constants.swift
+//  runnerpia
+//
+//  Created by 박경준 on 2023/06/13.
+//
+
+import Foundation
+//HTTP : http://pien.kr:3000
+//HTTPS: https://server.pien.kr:3000
+struct K {
+    struct ProductionServer {
+        static let baseURL = "https://server.pien.kr:3000"
+    }
+    
+    struct APIParameterKey {
+        // MARK: 유저 모델 관련 API 파라미터 키값 리스트
+        // Route 모델 파라미터 키와 중복될 수 있음
+        static let name = "name"
+        static let nickname = "nickname"
+        static let userId = "userId"
+        static let password = "password"
+        static let birthDate = "birthDate"
+        static let gender = "gender"
+        static let city = "city" // MARK: 추후 삭제가능
+        static let state = "state" // MARK: 추후 삭제가능
+        static let recommendedTags = "recommendedTags"
+        static let secureTags = "secureTags"
+        static let accessToken = "access_token"
+        static let refreshToken = "refresh_token"
+        
+        // MARK: Route 모델 관련 API 파라미터 키값 리스트
+        static let arrayOfPos = "arrayOfPos"
+        static let latitude = "latitude"
+        static let longitude = "longitude"
+        static let routeName = "routeName"
+        static let runningTime = "runningTime"
+        static let review = "review"
+        static let runningDate = "runningDate"
+        static let distance = "distance"
+        static let routeImage = "routeImage"
+        static let files = "files"
+        static let firstLocation = "firstLocation" // MARK: Location 하나로 통합 예정
+        static let secondLocation = "secondLocation" // MARK: Location 하나로 통합 예정
+        static let thirdLocation = "thirdLocation" // MARK: Location 하나로 통합 예정
+        static let mainRoute = "mainRoute"
+        static let id = "id"
+        static let user = "user"
+        static let startPoint = "startPoint"
+        static let subRoute = "subRoute"
+        static let check = "check"
+        static let result = "result"
+        static let count = "count"
+    }
+}
+
+enum HTTPHeaderField: String {
+    case authentication = "Authorization"
+    case contentType = "Content-Type"
+    case acceptType = "Accept"
+    case acceptEncoding = "Accept-Encoding"
+    case multipartFormdata = "multipart/form-data"
+}
+
+enum ContentType: String {
+    case json = "application/json"
+}


### PR DESCRIPTION
Alamofire HTTP 네트워크 통신 관련 좋은 레퍼런스가 있어서 참고하여 각종 열거형 정의 및 유저모델 네트워크 통신 기반 정리하였습니다.

## 사용법
기본적으로는 아래 레퍼런스로 추가해둔 미디엄 문서는 꼭 정독하시길 바라요!

1. `Util/Constants.swift` - `K` 구조체타입 선언 후 API 파라미터 키들을 문자열로 반환받기 위해 열거형 타입 선언했습니다.
2. HTTP 헤더 필드 열거형 정의 - 추후 미디어데이터 통신 시 수정 필요할 수도 있음
3. ContentType 열거형 - 2번과 동일
4. `Network/APIRouter.swift` - `APIConfiguration` 프로토콜 정의 , 모델별 엔드포인트를 구분하여 정의함. 노션 문서 기준 유저 관련 기능과 Route관련 기능으로 구분
5. 유저모델 관련 엔드포인트 메서드, 파라미터, url path 열거형 정의
6. 라우트 모델 관련 엔드포인트 추가 예정입니다.

## 참고사항
1. 서버 URL 수정되었습니다. 노션에 첨부하였으니 확인해주세요! `https://server.pien.kr:4500/`

## Reference
1. [swift4 - using alamofire and codable](https://medium.com/@AladinWay/write-a-networking-layer-in-swift-4-using-alamofire-and-codable-part-1-api-router-349699a47569)