### PR TITLE
feat: 메인루트 GET API 연동

### DIFF
--- a/runnerpia/Controllers/Main/My/MyReviewViewController.swift
+++ b/runnerpia/Controllers/Main/My/MyReviewViewController.swift
@@ -80,54 +80,7 @@ final class MyReviewViewController: UIViewController, UIGestureRecognizerDelegat
     
     // ⭐️ 추후 수정
     func setUpData() {
-        let firstData = Route(
-            user: User(userId: "주영", nickname: "Jess"),
-            routeName: "한강 잠실 러닝길",
-            distance: 100,
-            arrayOfPos: [CLLocationCoordinate2D(latitude: 37.2785, longitude: 127.1452),
-                         CLLocationCoordinate2D(latitude: 37.2779, longitude: 127.1452),
-                         CLLocationCoordinate2D(latitude: 37.2767, longitude: 127.1444)],
-            location: "송파구 잠실동",
-            runningTime: "100",
-            review: "300자가 어느 정도 되나 300자가 어느 정도 되나 300자가 어느 정도 되나 300자가 어느 정도 되나 300자가 어느 정도 되나",
-            runningDate: "12월 31일 토요일 오후 6~9시",
-            recommendedTags: ["1", "2"],
-            secureTags: ["1", "2", "3"]
-        )
-
-        let secondData = Route(
-            user: User(userId: "주영", nickname: "Jess"),
-            routeName: "송정 뚝방로",
-            distance: 200,
-            arrayOfPos: [CLLocationCoordinate2D(latitude: 37.2785, longitude: 127.1452),
-                         CLLocationCoordinate2D(latitude: 37.2779, longitude: 127.1452),
-                         CLLocationCoordinate2D(latitude: 37.2767, longitude: 127.1444)],
-            location: "성동구 송정도",
-            runningTime: "200",
-            review: "300자가 어느 정도 되나 1",
-            runningDate: "6월 12일 월요일 오후 6~9시",
-            recommendedTags: ["1", "2"],
-            secureTags: ["1", "2", "3"]
-        )
-
-        let thirdData = Route(
-            user: User(userId: "주영", nickname: "Jess"),
-            routeName: "용인시 수지구",
-            distance: 100,
-            arrayOfPos: [CLLocationCoordinate2D(latitude: 37.2785, longitude: 127.1452),
-                         CLLocationCoordinate2D(latitude: 37.2779, longitude: 127.1452),
-                         CLLocationCoordinate2D(latitude: 37.2767, longitude: 127.1444)],
-            location: "수지구청역",
-            runningTime: "300",
-            review: "300자가 어느 정도 되나3",
-            runningDate: "6월 11일 일요일 오후 6~9시",
-            recommendedTags: ["1", "2"],
-            secureTags: ["1", "2", "3"]
-        )
-
-        routeData.append(firstData)
-        routeData.append(secondData)
-        routeData.append(thirdData)
+      
     }
     
     private func configureUI() {

--- a/runnerpia/Controllers/Main/My/MyRunningViewController.swift
+++ b/runnerpia/Controllers/Main/My/MyRunningViewController.swift
@@ -80,54 +80,6 @@ final class MyRunningViewController: UIViewController, UIGestureRecognizerDelega
     
     // ⭐️ 추후 수정
     func setUpData() {
-        let firstData = Route(
-            user: User(userId: "주영", nickname: "Jess"),
-            routeName: "한강 잠실 러닝길",
-            distance: 100,
-            arrayOfPos: [CLLocationCoordinate2D(latitude: 37.2785, longitude: 127.1452),
-                         CLLocationCoordinate2D(latitude: 37.2779, longitude: 127.1452),
-                         CLLocationCoordinate2D(latitude: 37.2767, longitude: 127.1444)],
-            location: "송파구 잠실동",
-            runningTime: "100",
-            review: "300자가 어느 정도 되나 300자가 어느 정도 되나 300자가 어느 정도 되나 300자가 어느 정도 되나 300자가 어느 정도 되나",
-            runningDate: "12월 31일 토요일 오후 6~9시",
-            recommendedTags: ["1", "2"],
-            secureTags: ["1", "2", "3"]
-        )
-
-        let secondData = Route(
-            user: User(userId: "주영", nickname: "Jess"),
-            routeName: "송정 뚝방로",
-            distance: 200,
-            arrayOfPos: [CLLocationCoordinate2D(latitude: 37.2785, longitude: 127.1452),
-                         CLLocationCoordinate2D(latitude: 37.2779, longitude: 127.1452),
-                         CLLocationCoordinate2D(latitude: 37.2767, longitude: 127.1444)],
-            location: "성동구 송정도",
-            runningTime: "200",
-            review: "300자가 어느 정도 되나 1",
-            runningDate: "6월 12일 월요일 오후 6~9시",
-            recommendedTags: ["1", "2"],
-            secureTags: ["1", "2", "3"]
-        )
-
-        let thirdData = Route(
-            user: User(userId: "주영", nickname: "Jess"),
-            routeName: "용인시 수지구",
-            distance: 100,
-            arrayOfPos: [CLLocationCoordinate2D(latitude: 37.2785, longitude: 127.1452),
-                         CLLocationCoordinate2D(latitude: 37.2779, longitude: 127.1452),
-                         CLLocationCoordinate2D(latitude: 37.2767, longitude: 127.1444)],
-            location: "수지구청역",
-            runningTime: "300",
-            review: "300자가 어느 정도 되나3",
-            runningDate: "6월 11일 일요일 오후 6~9시",
-            recommendedTags: ["1", "2"],
-            secureTags: ["1", "2", "3"]
-        )
-
-        routeData.append(firstData)
-        routeData.append(secondData)
-        routeData.append(thirdData)
     }
     
     private func configureUI() {

--- a/runnerpia/Controllers/Main/Particular/ParticularRouteController.swift
+++ b/runnerpia/Controllers/Main/Particular/ParticularRouteController.swift
@@ -63,25 +63,7 @@ final class ParticularRouteController: UIViewController {
     
     // MARK: - Helpers
     
-    func setupData() -> Route {
-           let firstData = Route(
-               user: User(userId: "주영", nickname: "주영"),
-               routeName: "송정 뚝방길",
-               distance: 20,
-               arrayOfPos: [CLLocationCoordinate2D(latitude: 37.2785, longitude: 127.1452),
-                            CLLocationCoordinate2D(latitude: 37.2779, longitude: 127.1452),
-                            CLLocationCoordinate2D(latitude: 37.2767, longitude: 127.1444)],
-               location: "ㅁ",
-               runningTime: "",
-               review: "성동구에서 가장 안전한 루트를 소개합니다~!",
-               runningDate: "",
-               recommendedTags: ["1", "2"],
-               secureTags: ["1", "2", "3"],
-               files: [#imageLiteral(resourceName: "random6"), #imageLiteral(resourceName: "random4"), #imageLiteral(resourceName: "random5"), #imageLiteral(resourceName: "random1")]
-           )
-           
-           return firstData
-       }
+
     
     private func configureUI() {
         particularView.collectionView.tag = 1
@@ -175,7 +157,7 @@ extension ParticularRouteController: UICollectionViewDelegate, UICollectionViewD
             
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ParticularCollectionViewCell.identifier, for: indexPath) as? ParticularCollectionViewCell else { return UICollectionViewCell() }
             
-            cell.imageView.image = data?.files?[indexPath.item].scalePreservingAspectRatio(targetSize: CGSize(width: 100, height: 100))
+//            cell.imageView.image = data?.files?[indexPath.item].scalePreservingAspectRatio(targetSize: CGSize(width: 100, height: 100))
             cell.imageView.contentMode = .scaleAspectFill
             cell.imageView.clipsToBounds = true
             cell.imageView.layer.cornerRadius = 10

--- a/runnerpia/Controllers/Main/Particular/PhotoViewController.swift
+++ b/runnerpia/Controllers/Main/Particular/PhotoViewController.swift
@@ -83,7 +83,7 @@ final class PhotoViewController: UIViewController, UIScrollViewDelegate {
             imageView.contentMode = .scaleAspectFit
             let xPos = photoView.scrollView.frame.width * CGFloat(i)
             imageView.frame = CGRect(x: xPos, y: 0, width: photoView.scrollView.frame.width, height: photoView.scrollView.frame.height)
-            imageView.image = files[i]
+//            imageView.image = files[i]
             photoView.scrollView.addSubview(imageView)
             photoView.scrollView.contentSize.width = imageView.frame.width * CGFloat(i + 1)
         }

--- a/runnerpia/Controllers/Main/Post/PostDetailViewController.swift
+++ b/runnerpia/Controllers/Main/Post/PostDetailViewController.swift
@@ -238,41 +238,7 @@ extension PostDetailViewController: PhotoCollectionViewCellEventDelegate{
 
 extension PostDetailViewController: PostDetailViewEventDelegate{
     func registerButtonTapped(route: Route) {
-        let routeForServer = RouteForServer(
-        arrayOfPos: [
-            Coordinate(latitude: "37.33128013", longitude: "-122.03073774"),
-            Coordinate(latitude: "37.33128013", longitude: "-122.03073774")
-            ],
-        routeName: "송정뚝방길ewfoijioj",
-        runningTime: "01:01:01",
-        review: "testReview",
-        runningDate: "2022-01-01",
-        distance: "3.7",
-        files : [],
-        location: "ㄹ케",
-        recommendedTags: ["1","2","3"],
-        secureTags: ["1","2","3"]
-        )
-//        print("서버 저장용..")
-        print(routeForServer)
         
-        // MARK: routeForServer 인스턴스가 직렬화 되지 않음
-        
-        APIClient.postRoute(routeData: routeForServer) { result in
-            switch result{
-            case .success(let data):
-                print(data)
-            case .failure:
-                APIClient.retryAPIRequest(routeData: routeForServer, retryEndPoint: .postRoute(accessToken: "", route: routeForServer)) { result in
-                    switch result{
-                    case .success(let error):
-                        print(error)
-                    case .failure(let fatalError):
-                        print(fatalError)
-                    }
-                }
-            }
-        }
         
     }
 }

--- a/runnerpia/Controllers/Main/Post/PostDetailViewController.swift
+++ b/runnerpia/Controllers/Main/Post/PostDetailViewController.swift
@@ -237,8 +237,15 @@ extension PostDetailViewController: PhotoCollectionViewCellEventDelegate{
 }
 
 extension PostDetailViewController: PostDetailViewEventDelegate{
-    func registerButtonTapped(route: Route) {
+    func registerButtonTapped(arrayOfPos: [NMGLatLng], routeName: String, runningTime: String, review: String, runningDate: Date, distance: String, files: [String], location: String, recommendedTags: [String], secureTags: [String]) {
+        // MARK: arrayOfPos -> NMGLatLng에서 CLLocationCoordiate2D로 변경
+        // MARK: runningDate -> 현지시각으로 타임존 변경하고 string으로 푸시
         
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: Locale.current.identifier)
+        dateFormatter.timeZone = TimeZone(identifier: TimeZone.current.identifier)
+        dateFormatter.dateFormat = "yyyy-MM-dd"
         
+//        print(arrayOfPos, routeName, runningTime, review,runningDate, distance, files, location, recommendedTags, secureTags)
     }
 }

--- a/runnerpia/Controllers/Main/Post/PostDetailViewController.swift
+++ b/runnerpia/Controllers/Main/Post/PostDetailViewController.swift
@@ -246,6 +246,29 @@ extension PostDetailViewController: PostDetailViewEventDelegate{
         dateFormatter.timeZone = TimeZone(identifier: TimeZone.current.identifier)
         dateFormatter.dateFormat = "yyyy-MM-dd"
         
-//        print(arrayOfPos, routeName, runningTime, review,runningDate, distance, files, location, recommendedTags, secureTags)
+        
+        let data = Route(
+            arrayOfPos: arrayOfPos.map({ coord in
+                CLLocationCoordinate2D(latitude: coord.lat, longitude: coord.lng)}),
+            routeName: routeName,
+            runningTime: runningTime,
+            review: review,
+            runningDate: dateFormatter.string(from: runningDate),
+            distance: Double(distance)!,
+            files: files,
+            location: location,
+            recommendedTags: recommendedTags,
+            secureTags: secureTags,
+            mainRoute: 1
+        )
+        let encoder = JSONEncoder()
+        do{
+            let jsondata = try encoder.encode(data)
+            let json = String(data: jsondata, encoding: .utf8)
+            print(json)
+        }catch {
+            print("error..")
+        }
+        
     }
 }

--- a/runnerpia/Controllers/Main/Post/PostDetailViewController.swift
+++ b/runnerpia/Controllers/Main/Post/PostDetailViewController.swift
@@ -261,25 +261,21 @@ extension PostDetailViewController: PostDetailViewEventDelegate{
             secureTags: secureTags,
             mainRoute: 1
         )
-        let encoder = JSONEncoder()
         
-        do{
-            let jsondata = try encoder.encode(data)
-            let json = String(data: jsondata, encoding: .utf8)
-            print(json)
-        }catch {
-            print("error..")
+        APIClient.postRoute(routeData: data) { result in
+            switch(result){
+            case .success(let id):
+                print(id)
+            case .failure(let error):
+                APIClient.retryAPIRequest(routeData: data, retryEndPoint: .postRoute(accessToken: "", route: data)) { result in
+                    switch(result){
+                    case .success(let error):
+                        print("error: ", error)
+                    case .failure(let fatalError):
+                        print("fatal error:" , fatalError)
+                    }
+                }
+            }
         }
-        
-        do{
-            let decoder = JSONDecoder()
-            let jsondata = try encoder.encode(data)
-            let data2 = try decoder.decode(Route.self, from: jsondata)
-            print(data2)
-        }catch {
-            print(error)
-            print("decode error..")
-        }
-        
     }
 }

--- a/runnerpia/Controllers/Main/Post/PostDetailViewController.swift
+++ b/runnerpia/Controllers/Main/Post/PostDetailViewController.swift
@@ -224,6 +224,7 @@ extension PostDetailViewController: UITextViewDelegate{
 
 extension PostDetailViewController: PhotoCollectionViewCellEventDelegate{
     func removeButtonTapped(_ selected: PhotoCollectionViewCell){
+        print(selectedImages[1].jpegData(compressionQuality: 0)?.base64EncodedString())
         guard let removeIndex = selectedImages.firstIndex(of: selected.selectedImage!) else {return}
         selectedImages.remove(at: removeIndex)
         
@@ -240,11 +241,20 @@ extension PostDetailViewController: PostDetailViewEventDelegate{
     func registerButtonTapped(arrayOfPos: [NMGLatLng], routeName: String, runningTime: String, review: String, runningDate: Date, distance: String, files: [String], location: String, recommendedTags: [String], secureTags: [String]) {
         // MARK: arrayOfPos -> NMGLatLng에서 CLLocationCoordiate2D로 변경
         // MARK: runningDate -> 현지시각으로 타임존 변경하고 string으로 푸시
+        let view = self.view as! PostDetailView
+        view.indicatorView.startAnimating()
+        view.registerButton.isHidden = true
         
         let dateFormatter = DateFormatter()
         dateFormatter.locale = Locale(identifier: Locale.current.identifier)
         dateFormatter.timeZone = TimeZone(identifier: TimeZone.current.identifier)
         dateFormatter.dateFormat = "yyyy-MM-dd"
+        
+        let images = selectedImages.count > 0 ? Array(selectedImages[1..<selectedImages.count]) : []
+        let imagesString = images.map { imgData in
+            let compressed = imgData.scalePreservingAspectRatio(targetSize: CGSize(width: 20, height: 20))
+            return "data:image/jpeg;base64,\(compressed.pngData()!.base64EncodedString())"
+        }
         
         
         let data = Route(
@@ -255,7 +265,7 @@ extension PostDetailViewController: PostDetailViewEventDelegate{
             review: review,
             runningDate: dateFormatter.string(from: runningDate),
             distance: Double(distance)!,
-            files: files,
+            files: imagesString,
             location: location,
             recommendedTags: recommendedTags,
             secureTags: secureTags,
@@ -266,13 +276,29 @@ extension PostDetailViewController: PostDetailViewEventDelegate{
             switch(result){
             case .success(let id):
                 print(id)
-            case .failure(let error):
-                APIClient.retryAPIRequest(routeData: data, retryEndPoint: .postRoute(accessToken: "", route: data)) { result in
+                view.indicatorView.stopAnimating()
+                view.registerButton.isHidden = false
+                self.dismiss(animated: true)
+            case .failure(_):
+                APIClient.retryAPIRequestWithEntitiyError(routeData: data, retryEndPoint: .postRoute(accessToken: "", route: data)) { result in
                     switch(result){
-                    case .success(let error):
-                        print("error: ", error)
-                    case .failure(let fatalError):
-                        print("fatal error:" , fatalError)
+                    case .success(let entityError):
+                        print(entityError)
+                        view.indicatorView.stopAnimating()
+                        view.registerButton.isHidden = false
+                    case .failure(_):
+                        APIClient.retryAPIRequest(routeData: data, retryEndPoint: .postRoute(accessToken: "", route: data)) { result in
+                            switch(result){
+                            case .success(let networkError):
+                                print(networkError)
+                                view.indicatorView.stopAnimating()
+                                view.registerButton.isHidden = false
+                            case .failure(let fatalError):
+                                print(fatalError)
+                                view.indicatorView.stopAnimating()
+                                view.registerButton.isHidden = false
+                            }
+                        }
                     }
                 }
             }

--- a/runnerpia/Controllers/Main/Post/PostDetailViewController.swift
+++ b/runnerpia/Controllers/Main/Post/PostDetailViewController.swift
@@ -262,12 +262,23 @@ extension PostDetailViewController: PostDetailViewEventDelegate{
             mainRoute: 1
         )
         let encoder = JSONEncoder()
+        
         do{
             let jsondata = try encoder.encode(data)
             let json = String(data: jsondata, encoding: .utf8)
             print(json)
         }catch {
             print("error..")
+        }
+        
+        do{
+            let decoder = JSONDecoder()
+            let jsondata = try encoder.encode(data)
+            let data2 = try decoder.decode(Route.self, from: jsondata)
+            print(data2)
+        }catch {
+            print(error)
+            print("decode error..")
         }
         
     }

--- a/runnerpia/Controllers/Recommend/List/RecommendViewController.swift
+++ b/runnerpia/Controllers/Recommend/List/RecommendViewController.swift
@@ -14,11 +14,27 @@ class RecommendViewController: UIViewController {
         
         let recommendView = RecommendView()
         self.view = recommendView
+        
+        fetchData()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         UserLocationManager.shared.stopUpdatingLocation()
+    }
+    
+    func fetchData(){
+        let view = self.view as! RecommendView
+        APIClient.getRoute(routeId: 1) { result in
+            switch(result){
+            case .success(let mainRoute):
+                print(mainRoute)
+                view.indicatorView.stopAnimating()
+                view.indicatorView.hidesWhenStopped = true
+            case .failure(let error):
+                print(error)
+            }
+        }
     }
 
 }

--- a/runnerpia/Controllers/Search/SearchViewController.swift
+++ b/runnerpia/Controllers/Search/SearchViewController.swift
@@ -18,7 +18,6 @@ final class SearchViewController: UIViewController, NMFMapViewTouchDelegate {
     var locationManager = CLLocationManager()
     var halfModalView = HalfModalView()
     let marker = NMFMarker()
-    let data = Route(user: User(userId: "경준", nickname: "경준"),routeName: "동백 호수공원",distance: 200,arrayOfPos: [CLLocationCoordinate2D(latitude: 37.2785, longitude: 127.1452),CLLocationCoordinate2D(latitude: 37.2779, longitude: 127.1452),CLLocationCoordinate2D(latitude: 37.2767, longitude: 127.1444)], location:"기흥구 언동로" , runningTime: "200분", review: "나무가 풍성한 동백 호수공원을 달려보아요", runningDate: "12월 30일 일요일 오후 2~3시", recommendedTags: ["0","1","2"], secureTags: ["0","1", "2", "3", "4"], files:[UIImage(named: "test1")!, UIImage(named:"test2")!, UIImage(named:"test3")!, UIImage(named:"test4")!])
 
     let pathOverlay = NMFPath()
 
@@ -31,7 +30,7 @@ final class SearchViewController: UIViewController, NMFMapViewTouchDelegate {
         configureNavigation()
         configureDelegate()
         requestLocationPermissionAuthorization()
-        configureMap()
+        
     }
     
     override func loadView() {
@@ -64,9 +63,6 @@ final class SearchViewController: UIViewController, NMFMapViewTouchDelegate {
         searchView.map.touchDelegate = self
     }
     
-    func mapView(_ mapView: NMFMapView, didTapMap latlng: NMGLatLng, point: CGPoint) {
-    }
-    
 }
 
 
@@ -87,53 +83,33 @@ extension SearchViewController: CLLocationManagerDelegate, UIViewControllerTrans
         let cameraUpdate = NMFCameraUpdate(scrollTo: NMGLatLng(lat: locationManager.location?.coordinate.latitude ?? 0, lng: locationManager.location?.coordinate.longitude ?? 0))
         cameraUpdate.animation = .easeIn
         searchView.map.moveCamera(cameraUpdate)
-        
-        // MARK: 좌표바인딩 및 데이터 변환
-        let nmgCoordinates = data.arrayOfPos!.map { coordinate in
-            NMGLatLng(lat: coordinate.latitude, lng: coordinate.longitude)
-        }
-        
-        
-        // 2. 경로 오버레이 표시
-        pathOverlay.path = NMGLineString(points: nmgCoordinates)
-        pathOverlay.color = .clear
-        pathOverlay.outlineColor = .clear
-        pathOverlay.width = 10
-        pathOverlay.mapView = searchView.map
-        
-        let locationOverlay = searchView.map.locationOverlay
-        locationOverlay.icon = NMFOverlayImage(name: "myLocation")
-        
-    }
-    
-    private func configureMap() {
-        addMarker()
     }
 
-    
-    func addMarker() {
-        marker.position = NMGLatLng(lat: data.arrayOfPos!.first!.latitude, lng: data.arrayOfPos!.first!.longitude)
-        marker.mapView = searchView.map
-        
-        let viewMarker = createViewMarker()
-        marker.iconImage = NMFOverlayImage(image: viewMarker.asImage())
 
-        // 마커 터치핸들러
-        marker.touchHandler = { [self] (overlay: NMFOverlay) -> Bool in
-            presentHalfModal()
-            locationManager.stopUpdatingLocation()
-            searchView.map.positionMode = .disabled
-            overlay.globalZIndex = 10
-            pathOverlay.color = .white
-            pathOverlay.mapView = searchView.map
-            
-            return true
-        }
-    }
+    
+//    func addMarker() {
+////        marker.position = NMGLatLng(lat: data.arrayOfPos!.first!.latitude, lng: data.arrayOfPos!.first!.longitude)
+//        marker.mapView = searchView.map
+//
+//        let viewMarker = createViewMarker()
+//        marker.iconImage = NMFOverlayImage(image: viewMarker.asImage())
+//
+//        // 마커 터치핸들러
+//        marker.touchHandler = { [self] (overlay: NMFOverlay) -> Bool in
+//            presentHalfModal()
+//            locationManager.stopUpdatingLocation()
+//            searchView.map.positionMode = .disabled
+//            overlay.globalZIndex = 10
+//            pathOverlay.color = .white
+//            pathOverlay.mapView = searchView.map
+//
+//            return true
+//        }
+//    }
     
     func createViewMarker() -> UIImageView {
         let leftLabelText = "2"
-        let rightLabelText = data.distance
+//        let rightLabelText = data.distance
         
         let locationMarker = UIImageView() // 최소 사이즈 설정
         locationMarker.image = UIImage(named: "tooltip")?.scalePreservingAspectRatio(targetSize: CGSize(width: 120, height: 50))
@@ -176,11 +152,11 @@ extension SearchViewController: CLLocationManagerDelegate, UIViewControllerTrans
         
         
         let rightLabel = UILabel()
-        if let unwrappedDistance = rightLabelText {
-            rightLabel.text = "\(unwrappedDistance)km"
-        } else {
-            rightLabel.text = ""
-        }
+//        if let unwrappedDistance = rightLabelText {
+//            rightLabel.text = "\(unwrappedDistance)km"
+//        } else {
+//            rightLabel.text = ""
+//        }
         
         rightLabel.textColor = .white
         rightLabel.font = .regular12
@@ -205,14 +181,13 @@ extension SearchViewController: CLLocationManagerDelegate, UIViewControllerTrans
         let halfModalViewController = HalfModalPresentationController()
         halfModalViewController.modalPresentationStyle = .custom
         halfModalViewController.halfModalView.layer.cornerRadius = 40
-        halfModalViewController.transitioningDelegate = self
+//        halfModalViewController.transitioningDelegate = self
         
         // MARK: 데이터 바인딩
-        halfModalViewController.data = self.data
+//        halfModalViewController.data = self.data
         
-        present(halfModalViewController, animated: true, completion: nil)
+//        present(halfModalViewController, animated: true, completion: nil)
     }
-
 }
 
 

--- a/runnerpia/Extensions/UIImage.swift
+++ b/runnerpia/Extensions/UIImage.swift
@@ -58,4 +58,8 @@ extension UIImage{
             return scaledImage
         }
     }
+    
+    public var base64: String {
+        return self.jpegData(compressionQuality: 0)!.base64EncodedString()
+    }
 }

--- a/runnerpia/Models/Route.swift
+++ b/runnerpia/Models/Route.swift
@@ -41,7 +41,15 @@ struct Route: Loopable, Codable{
     
     init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
-        arrayOfPos = try decoder.singleValueContainer().decode([CLLocationCoordinate2D].self)
+        // 에러아님
+        let posArray = try values.decode([[String:Double]].self, forKey: .arrayOfPos)
+        let posData = posArray.map { dict in
+            let latitude = dict["latitude"] ?? 0.0
+            let longitude = dict["longitude"] ?? 0.0
+            return CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+        }
+        arrayOfPos = posData
+        
         routeName = try values.decode(String.self, forKey: .routeName)
         runningTime = try values.decode(String.self, forKey: .runningTime)
         review = try values.decode(String.self, forKey: .review)
@@ -49,13 +57,16 @@ struct Route: Loopable, Codable{
         distance = try values.decode(Double.self, forKey: .distance)
         
         // MARK: String 배열
-        files = try decoder.singleValueContainer().decode([String].self)
+        print("files?")
+        files = try values.decode([String].self, forKey: .files)
         
         location = try values.decode(String.self, forKey: .location)
         
         // MARK: String 배열
-        recommendedTags = try decoder.singleValueContainer().decode([String].self)
-        secureTags = try decoder.singleValueContainer().decode([String].self)
+        
+        print("recommended?")
+        recommendedTags = try values.decode([String].self, forKey: .recommendedTags)
+        secureTags = try values.decode([String].self, forKey: .secureTags)
         
         mainRoute = try values.decode(Int.self, forKey: .mainRoute)
     }

--- a/runnerpia/Models/Route.swift
+++ b/runnerpia/Models/Route.swift
@@ -12,77 +12,89 @@ import UIKit
 // MARK: 커스텀타입을 전달하려면 해당 타입도 Codable을 채택해야함.
 // MARK: CLLocationCoordinate2D에 대한 새로운 타입 정의 필요
 
-struct Route: Loopable{
-    let user: User?
-    let routeName: String?
-    let distance: Double?
+struct Route: Loopable, Codable{
     let arrayOfPos: [CLLocationCoordinate2D]?
-    let location: String?
+    let routeName: String?
     let runningTime: String?
     let review: String?
     let runningDate: String?
+    let distance: Double?
+    let files: [String]?
+    let location: String?
     let recommendedTags: [String]?
     let secureTags: [String]?
-    var files: [UIImage]?
+    let mainRoute: Int?
+    
+    enum CodingKeys: String, CodingKey{
+        case arrayOfPos
+        case routeName
+        case runningTime
+        case review
+        case runningDate
+        case distance
+        case files
+        case location
+        case recommendedTags
+        case secureTags
+        case mainRoute
+    }
+    
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        arrayOfPos = try decoder.singleValueContainer().decode([CLLocationCoordinate2D].self)
+        routeName = try values.decode(String.self, forKey: .routeName)
+        runningTime = try values.decode(String.self, forKey: .runningTime)
+        review = try values.decode(String.self, forKey: .review)
+        runningDate = try values.decode(String.self, forKey: .runningDate)
+        distance = try values.decode(Double.self, forKey: .distance)
+        
+        // MARK: String 배열
+        files = try decoder.singleValueContainer().decode([String].self)
+        
+        location = try values.decode(String.self, forKey: .location)
+        
+        // MARK: String 배열
+        recommendedTags = try decoder.singleValueContainer().decode([String].self)
+        secureTags = try decoder.singleValueContainer().decode([String].self)
+        
+        mainRoute = try values.decode(Int.self, forKey: .mainRoute)
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(arrayOfPos, forKey: .arrayOfPos)
+        try container.encode(routeName, forKey: .routeName)
+        try container.encode(runningTime, forKey: .runningTime)
+        try container.encode(review, forKey: .review)
+        try container.encode(runningDate, forKey: .runningDate)
+        try container.encode(distance, forKey: .distance)
+        try container.encode(files, forKey: .files)
+        try container.encode(location, forKey: .location)
+        try container.encode(recommendedTags, forKey: .recommendedTags)
+        try container.encode(secureTags, forKey: .secureTags)
+        try container.encode(mainRoute, forKey: .mainRoute)
+    }
 }
 
-
-// MARK: Codable용 타입과 별개로 UI에서 사용될 타입을 정의해야되나?
-struct Coordinate: Codable{
-    // MARK: 커스텀 인스턴스를 직렬화
-    // MARK: Codable을 해치지는 않지만 Serialize가 되는지
-    let latitude: String
-    let longitude: String
-}
+extension CLLocationCoordinate2D: Codable {
+     public func encode(to encoder: Encoder) throws {
+         var container = encoder.unkeyedContainer()
+         try container.encode(longitude)
+         try container.encode(latitude)
+     }
+      
+     public init(from decoder: Decoder) throws {
+         var container = try decoder.unkeyedContainer()
+         let longitude = try container.decode(CLLocationDegrees.self)
+         let latitude = try container.decode(CLLocationDegrees.self)
+         self.init(latitude: latitude, longitude: longitude)
+     }
+ }
 
 struct RouteId: Codable{
     let routeId: Int
     
     enum CodingKeys: String, CodingKey{
         case routeId = "routeId"
-    }
-}
-
-struct RouteForServer: Codable{
-    let arrayOfPos: [Coordinate]
-    let routeName: String
-    let runningTime: String
-    let review: String
-    let runningDate: String
-    let distance: String
-    let files: [String]
-    let location: String
-    let recommendedTags: [String]
-    let secureTags: [String]
-    
-    enum CodingKeys: String, CodingKey{
-        case arrayOfPos = "arrayOfPos"
-        case routeName = "routeName"
-        case runningTime = "runningTime"
-        case review = "review"
-        case runningDate = "runningDate"
-        case distance = "distance"
-        case files = "files"
-        case location = "location"
-        case recommendedTags = "recommendedTags"
-        case secureTags = "secureTags"
-    }
-}
-
-struct Image: Codable{
-    public let photo: String
-    
-    public init(photo: UIImage){
-        guard let imageData = photo.pngData() else {
-            self.photo = ""
-            return
-        }
-        self.photo = imageData.base64EncodedString(options: .lineLength64Characters)
-    }
-}
-
-extension Image{
-    enum CodingKeys: String, CodingKey{
-        case photo
     }
 }

--- a/runnerpia/Models/Route.swift
+++ b/runnerpia/Models/Route.swift
@@ -98,6 +98,83 @@ struct Route: Loopable, Codable{
     }
 }
 
+struct MainRoute: Codable{
+    let id: Int
+    let routeName: String
+    let startLatitude: String
+    let startLongitude: String
+    let runningTime: String
+    let review: String
+    let distance: Int
+    let runningDate: String
+    let location: String
+    let mainRouteId: Int?
+    let user: [String: String]
+    let routeRecommendedTags: [[String: Int]]
+    let routeSecureTags: [[String: Int]]
+    let images: [[String: String]]
+    let subRoute: [SubRoute]
+    let recommendedTags: [String: Int]
+    let secureTags: [String: Int]
+    
+    enum CodingKeys: String, CodingKey{
+        case id
+        case routeName
+        case startLatitude
+        case startLongitude
+        case runningTime
+        case review
+        case distance
+        case runningDate
+        case location
+        case mainRouteId
+        case user
+        case routeRecommendedTags
+        case routeSecureTags
+        case images
+        case subRoute
+        case recommendedTags
+        case secureTags
+    }
+}
+
+struct SubRoute: Codable{
+    let id: Int
+    let routeName: String
+    let startLatitude: String
+    let startLongitude: String
+    let runningTime: String
+    let review: String
+    let distance: Int
+    let runningDate: String
+    let location: String
+    let mainRouteId: Int
+    let user: [String: String]
+    let routeRecommendedTags: [[String: Int]]
+    let routeSecureTags: [[String: Int]]
+    let images: [[String: String]]
+    let subRoute: [[String: String]]
+    let runningRoutePaths: [[String: String]]
+    
+    enum CodingKeys: String, CodingKey{
+        case id
+        case routeName
+        case startLatitude
+        case startLongitude
+        case runningTime
+        case review
+        case distance
+        case runningDate
+        case location
+        case mainRouteId
+        case user
+        case routeRecommendedTags
+        case routeSecureTags
+        case images
+        case subRoute
+        case runningRoutePaths
+    }
+}
 
 extension CLLocationCoordinate2D: Codable {
      public func encode(to encoder: Encoder) throws {

--- a/runnerpia/Models/Route.swift
+++ b/runnerpia/Models/Route.swift
@@ -57,14 +57,11 @@ struct Route: Loopable, Codable{
         distance = try values.decode(Double.self, forKey: .distance)
         
         // MARK: String 배열
-        print("files?")
         files = try values.decode([String].self, forKey: .files)
         
         location = try values.decode(String.self, forKey: .location)
         
         // MARK: String 배열
-        
-        print("recommended?")
         recommendedTags = try values.decode([String].self, forKey: .recommendedTags)
         secureTags = try values.decode([String].self, forKey: .secureTags)
         

--- a/runnerpia/Models/Route.swift
+++ b/runnerpia/Models/Route.swift
@@ -60,6 +60,20 @@ struct Route: Loopable, Codable{
         mainRoute = try values.decode(Int.self, forKey: .mainRoute)
     }
     
+    init(arrayOfPos: [CLLocationCoordinate2D], routeName: String,runningTime: String, review: String, runningDate: String, distance: Double, files: [String], location: String, recommendedTags: [String], secureTags: [String], mainRoute: Int){
+        self.arrayOfPos = arrayOfPos
+        self.routeName = routeName
+        self.runningTime = runningTime
+        self.review = review
+        self.runningDate = runningDate
+        self.distance = distance
+        self.files = files
+        self.location = location
+        self.recommendedTags = recommendedTags
+        self.secureTags = secureTags
+        self.mainRoute = mainRoute
+    }
+    
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(arrayOfPos, forKey: .arrayOfPos)
@@ -76,11 +90,12 @@ struct Route: Loopable, Codable{
     }
 }
 
+
 extension CLLocationCoordinate2D: Codable {
      public func encode(to encoder: Encoder) throws {
-         var container = encoder.unkeyedContainer()
-         try container.encode(longitude)
-         try container.encode(latitude)
+         var container = encoder.container(keyedBy: CodingKeys.self)
+         try container.encode(longitude, forKey: .longitude)
+         try container.encode(latitude, forKey: .latitude)
      }
       
      public init(from decoder: Decoder) throws {
@@ -89,6 +104,11 @@ extension CLLocationCoordinate2D: Codable {
          let latitude = try container.decode(CLLocationDegrees.self)
          self.init(latitude: latitude, longitude: longitude)
      }
+    
+    enum CodingKeys: String, CodingKey{
+        case latitude
+        case longitude
+    }
  }
 
 struct RouteId: Codable{

--- a/runnerpia/Network/APIClient.swift
+++ b/runnerpia/Network/APIClient.swift
@@ -18,11 +18,11 @@ class APIClient {
         }
     }
     
-    static func postRoute(routeData: RouteForServer, completion: @escaping (Result<RouteId, AFError>) -> Void){
+    static func postRoute(routeData: Route, completion: @escaping (Result<RouteId, AFError>) -> Void){
         performRequest(route: .postRoute(accessToken: "", route: routeData), completion: completion)
     }
     
-    static func retryAPIRequest(routeData: RouteForServer, retryEndPoint: RouteEndPoint, completion: @escaping (Result<NetworkError, AFError>) -> Void){
+    static func retryAPIRequest(routeData: Route, retryEndPoint: RouteEndPoint, completion: @escaping (Result<NetworkError, AFError>) -> Void){
         performRequest(route: retryEndPoint, completion: completion)
     }
     

--- a/runnerpia/Network/APIClient.swift
+++ b/runnerpia/Network/APIClient.swift
@@ -22,9 +22,16 @@ class APIClient {
         performRequest(route: .postRoute(accessToken: "", route: routeData), completion: completion)
     }
     
+    static func getRoute(routeId: Int, completion: @escaping (Result<MainRoute, AFError>) -> Void){
+        performRequest(route: .getRoute(accessToken: "", id: routeId), completion: completion)
+    }
+    
     static func retryAPIRequest(routeData: Route, retryEndPoint: RouteEndPoint, completion: @escaping (Result<NetworkError, AFError>) -> Void){
         performRequest(route: retryEndPoint, completion: completion)
     }
     
-    
+    // 임시 - 에러타입 통일 후 삭제예정
+    static func retryAPIRequestWithEntitiyError(routeData: Route, retryEndPoint: RouteEndPoint, completion: @escaping (Result<NetworkErrorWithEntitiyLarge, AFError>) -> Void){
+        performRequest(route: retryEndPoint, completion: completion)
+    }
 }

--- a/runnerpia/Network/APIRouter.swift
+++ b/runnerpia/Network/APIRouter.swift
@@ -132,7 +132,7 @@ enum UserEndPoint: APIConfiguration{
 
 // MARK: RouteEndpoint
 enum RouteEndPoint: APIConfiguration{
-    case postRoute(accessToken: String, route: RouteForServer)
+    case postRoute(accessToken: String, route: Route)
     case getRoute(accessToken: String, id: Int)
     case getReview(accessToken: String, id: Int)
     case modifyRoute(accessToken: String, modifiedRoute: Route, id: Int)
@@ -213,10 +213,8 @@ enum RouteEndPoint: APIConfiguration{
     var parameters: Alamofire.Parameters? {
         switch self{
         case .postRoute(_, let route):
-            let array = route.arrayOfPos.map({ coor in
-                ["latitude": coor.latitude, "longitude": coor.longitude]})
             return [
-                K.APIParameterKey.arrayOfPos: array,
+                K.APIParameterKey.arrayOfPos: route.arrayOfPos,
                 K.APIParameterKey.routeName: route.routeName ,
                 K.APIParameterKey.runningTime: route.runningTime ,
                 K.APIParameterKey.review: route.review,
@@ -226,7 +224,7 @@ enum RouteEndPoint: APIConfiguration{
                 K.APIParameterKey.location: route.location,
                 K.APIParameterKey.recommendedTags: route.recommendedTags,
                 K.APIParameterKey.secureTags: route.secureTags,
-//                K.APIParameterKey.mainRoute: route.mainRoute
+                K.APIParameterKey.mainRoute: route.mainRoute
             ]
         case .getRoute:
             return [:]

--- a/runnerpia/Network/APIRouter.swift
+++ b/runnerpia/Network/APIRouter.swift
@@ -214,17 +214,22 @@ enum RouteEndPoint: APIConfiguration{
         switch self{
         case .postRoute(_, let route):
             return [
-                K.APIParameterKey.arrayOfPos: route.arrayOfPos,
-                K.APIParameterKey.routeName: route.routeName ,
-                K.APIParameterKey.runningTime: route.runningTime ,
-                K.APIParameterKey.review: route.review,
-                K.APIParameterKey.runningDate: route.runningDate ,
-                K.APIParameterKey.distance: route.distance,
-                K.APIParameterKey.files: route.files,
-                K.APIParameterKey.location: route.location,
-                K.APIParameterKey.recommendedTags: route.recommendedTags,
-                K.APIParameterKey.secureTags: route.secureTags,
-                K.APIParameterKey.mainRoute: route.mainRoute
+                K.APIParameterKey.arrayOfPos: route.arrayOfPos!.map({ coord in
+                    return [
+                        "latitude": coord.latitude,
+                        "longitude": coord.longitude
+                    ]
+                }),
+                K.APIParameterKey.routeName: route.routeName! ,
+                K.APIParameterKey.runningTime: route.runningTime! ,
+                K.APIParameterKey.review: route.review!,
+                K.APIParameterKey.runningDate: route.runningDate! ,
+                K.APIParameterKey.distance: String(route.distance!),
+                K.APIParameterKey.files: route.files!,
+                K.APIParameterKey.location: route.location!,
+                K.APIParameterKey.recommendedTags: route.recommendedTags!,
+                K.APIParameterKey.secureTags: route.secureTags!,
+                K.APIParameterKey.mainRoute: route.mainRoute!
             ]
         case .getRoute:
             return [:]
@@ -283,6 +288,7 @@ enum RouteEndPoint: APIConfiguration{
         // Parameters
         if let parameters = parameters {
             do {
+                print(parameters)
                 urlRequest.httpBody = try JSONSerialization.data(withJSONObject: parameters, options: [])
             } catch {
                 throw AFError.parameterEncodingFailed(reason: .jsonEncodingFailed(error: error))

--- a/runnerpia/Network/APIRouter.swift
+++ b/runnerpia/Network/APIRouter.swift
@@ -232,7 +232,7 @@ enum RouteEndPoint: APIConfiguration{
                 K.APIParameterKey.mainRoute: route.mainRoute!
             ]
         case .getRoute:
-            return [:]
+            return nil
         case .getReview:
             return [:]
         // MARK: 수정 대상 데이터만 선택해서 저장 - Loopable 프로토콜 채택

--- a/runnerpia/Network/NetworkError.swift
+++ b/runnerpia/Network/NetworkError.swift
@@ -18,3 +18,13 @@ struct NetworkError: Codable, Error{
         case error = "error"
     }
 }
+
+struct NetworkErrorWithEntitiyLarge:Codable{
+    let statusCode: Int
+    let message: String
+    
+    enum CodingKeys: String, CodingKey{
+        case statusCode
+        case message
+    }
+}

--- a/runnerpia/Util/Tags.swift
+++ b/runnerpia/Util/Tags.swift
@@ -10,18 +10,18 @@ import Foundation
 let globalRecommendedTags: [String] = ["강을 보며 달려요", "나무가 많아요", "길이 깨끗해요", "가파른 구간이 없어요", "보행자 전용 트랙이 있어요"]
 let globalSecureTags: [String] = ["근처에 어린이 보호구역이 있어요","안심등이 있어요","가로등이 많아요","밤에 사람이 많아요", "낮에 사람이 많아요"]
 
-enum NormalTags{
-    case river
-    case woody
-    case clean
-    case flat
-    case walkerTrack
-}
-
-enum SecureTags{
-    case schoolZone
-    case safetyPole
-    case streetLight
-    case manyPeopleInNight
-    case manyPeopleInNoon
-}
+//enum RecommendedTags: String{
+//    case river = "강을 보며 달려요"
+//    case tree = "나무가 많아요"
+//    case clean = "길이 깨끗해요"
+//    case uphill = "가파른 구간이 없어요"
+//    case walker = "보행자 전용 트랙이 있어요"
+//}
+//
+//enum GlobalTags: String{
+//    case child = "근처에 어린이 보호구역이 있어요"
+//    case safe = "안심등이 있어요"
+//    case lamp = "가로등이 많아요"
+//    case night = "밤에 사람이 많아요"
+//    case noon = "낮에 사람이 많아요"
+//}

--- a/runnerpia/Views/Main/Post/PostDetailView.swift
+++ b/runnerpia/Views/Main/Post/PostDetailView.swift
@@ -15,11 +15,16 @@ class PostDetailView: UIView {
     
     // MARK: 경로 생성시 RouteView로부터 새롭게 생성되어 바인딩되는 데이터
     var bindingData: (Date, (TimeInterval, TimeInterval), (Int, Int), [NMGLatLng])?{
-        
         didSet{
             updateUI()
         }
     }
+    
+    let indicatorView: UIActivityIndicatorView = {
+        let iv = UIActivityIndicatorView()
+        iv.hidesWhenStopped = true
+        return iv
+    }()
     
     let scrollView: UIScrollView = {
         let sv = UIScrollView()
@@ -512,7 +517,7 @@ class PostDetailView: UIView {
 extension PostDetailView: LayoutProtocol{
     func setSubViews() {
         self.addSubview(scrollView)
-        [map, pathSectionLabel, pathNameTextField, pathInformationSectionLabel, locationView, dateView, timeView, distanceView, divider, rateSectionLabel, secureTagSectionLabel, secureTagCollectionView, normalTagSectionLabel, normalTagCollectionView, dividerAfterTag, introduceSectionLabel, introduceTextField, numberOfTextInput, photoSectionLabel, photoCollectionView, registerButton].forEach { scrollView.subviews.first!.addSubview($0) }
+        [map, pathSectionLabel, pathNameTextField, pathInformationSectionLabel, locationView, dateView, timeView, distanceView, divider, rateSectionLabel, secureTagSectionLabel, secureTagCollectionView, normalTagSectionLabel, normalTagCollectionView, dividerAfterTag, introduceSectionLabel, introduceTextField, numberOfTextInput, photoSectionLabel, photoCollectionView, registerButton, indicatorView].forEach { scrollView.subviews.first!.addSubview($0) }
     }
     func setLayout() {
         scrollView.snp.makeConstraints {
@@ -651,6 +656,11 @@ extension PostDetailView: LayoutProtocol{
             $0.trailing.equalTo(photoCollectionView.snp.trailing)
             $0.height.equalTo(56)
             $0.bottom.equalTo(scrollView.snp.bottom).offset(-20)
+        }
+        
+        indicatorView.snp.makeConstraints {
+            $0.top.equalTo(photoCollectionView.snp.bottom).offset(50)
+            $0.centerX.equalTo(self.snp.centerX)
         }
     }
 }

--- a/runnerpia/Views/Main/Post/PostDetailView.swift
+++ b/runnerpia/Views/Main/Post/PostDetailView.swift
@@ -15,15 +15,9 @@ class PostDetailView: UIView {
     
     // MARK: 경로 생성시 RouteView로부터 새롭게 생성되어 바인딩되는 데이터
     var bindingData: (Date, (TimeInterval, TimeInterval), (Int, Int), [NMGLatLng])?{
+        
         didSet{
             updateUI()
-        }
-    }
-    
-    // MARK: 경로 따라가기에서 생성되어 바인딩되는 데이터
-    var followRouteData: Route?{
-        didSet{
-            updateWithFollowingData()
         }
     }
     
@@ -339,8 +333,14 @@ class PostDetailView: UIView {
             }
         }
         
+        var distanceString = "\(distance.0)."
+        let distanceM = distance.1 / 10 > 0 ? "\(distance.1)" : "0\(distance.1)"
+        distanceString += distanceM
+        
+        // MARK: 이미지 to string 작업 필요
+        
     
-//        eventDelegate?.registerButtonTapped(route: routeData)
+        eventDelegate?.registerButtonTapped(arrayOfPos: coordinates, routeName: pathNameTextField.text!, runningTime: timeLabel.text!, review: introduceTextField.text, runningDate: date, distance: distanceString, files: [], location: startLocationLabel.text!, recommendedTags: selectedNormalTags, secureTags: selectedSecureTags)
     }
     
     // MARK: Helpers
@@ -448,10 +448,6 @@ class PostDetailView: UIView {
         let (km, meter) = distance
         let distanceLabel = distanceView.subviews.last as! UILabel
         distanceLabel.text = meter / 10 > 0 ? "\(km).\(meter)km" : "\(km).0\(meter)km"
-    }
-    
-    func updateWithFollowingData(){
-        
     }
     
     // MARK: 텍스트뷰 notification 추가 후, 텍스트뷰 editing 진입에 따라 뷰 조정해줘야함
@@ -660,5 +656,5 @@ extension PostDetailView: LayoutProtocol{
 }
 
 protocol PostDetailViewEventDelegate{
-    func registerButtonTapped(route: Route)
+    func registerButtonTapped(arrayOfPos: [NMGLatLng], routeName: String, runningTime: String, review:String, runningDate: Date, distance: String, files: [String], location: String, recommendedTags: [String], secureTags: [String])
 }

--- a/runnerpia/Views/Main/Post/PostDetailView.swift
+++ b/runnerpia/Views/Main/Post/PostDetailView.swift
@@ -339,11 +339,8 @@ class PostDetailView: UIView {
             }
         }
         
-        let routeData = Route(user: nil, routeName:  pathSectionLabel.text, distance: Double(distance.0 + distance.1 / 100) , arrayOfPos: coordinates.map({ coord in
-            CLLocationCoordinate2D(latitude: coord.lat, longitude: coord.lng)
-        }), location: startLocationLabel.text, runningTime: timeLabel.text, review: introduceTextField.text, runningDate: dateLabel.text, recommendedTags: selectedNormalTags, secureTags: selectedSecureTags)
     
-        eventDelegate?.registerButtonTapped(route: routeData)
+//        eventDelegate?.registerButtonTapped(route: routeData)
     }
     
     // MARK: Helpers

--- a/runnerpia/Views/Recommend/List/RecommendView.swift
+++ b/runnerpia/Views/Recommend/List/RecommendView.swift
@@ -13,6 +13,13 @@ class RecommendView: UIView {
     let imageCache = NSCache<NSString, UIImage>()
     var imageHashArray: [String] = []
     
+    let indicatorView: UIActivityIndicatorView = {
+        let iv = UIActivityIndicatorView()
+        iv.hidesWhenStopped = false
+        iv.startAnimating()
+        return iv
+    }()
+    
     let mainLabel: UILabel = {
         let label = UILabel()
         let paragraphStyle = NSMutableParagraphStyle()
@@ -73,7 +80,7 @@ class RecommendView: UIView {
 // MARK: - Layouts
 extension RecommendView: LayoutProtocol{
     func setSubViews() {
-        [mainLabel, tableView].forEach { self.addSubview($0) }
+        [mainLabel, tableView, indicatorView].forEach { self.addSubview($0) }
     }
     
     func setLayout() {
@@ -87,6 +94,11 @@ extension RecommendView: LayoutProtocol{
             $0.leading.equalToSuperview().offset(Constraints.paddingLeftAndRight)
             $0.trailing.equalToSuperview().offset(-Constraints.paddingLeftAndRight)
             $0.bottom.equalToSuperview().offset(-100)
+        }
+        
+        indicatorView.snp.makeConstraints {
+            $0.centerY.equalTo(self.snp.centerY)
+            $0.centerX.equalTo(self.snp.centerX)
         }
     }
 }

--- a/runnerpia/Views/Recommend/List/RecommendView.swift
+++ b/runnerpia/Views/Recommend/List/RecommendView.swift
@@ -44,9 +44,6 @@ class RecommendView: UIView {
         setSubViews()
         setLayout()
         configureUI()
-        
-        // 하드코딩함수 - 나중에 지울 예정!
-        setupData()
     }
     
     required init?(coder: NSCoder) {
@@ -71,17 +68,6 @@ class RecommendView: UIView {
         tableView.estimatedRowHeight = 220
     }
 
-    private func setupData(){
-        let firstData = Route(user: User(userId: "경준", nickname: "경준"), routeName: "한강 잠실 러닝길한강 잠실 러닝길한강 잠실 러닝길" ,distance: 500, arrayOfPos: [CLLocationCoordinate2D(latitude: 37.2785, longitude: 127.1452),CLLocationCoordinate2D(latitude: 37.2779, longitude: 127.1452),CLLocationCoordinate2D(latitude: 37.2767, longitude: 127.1444)], location:"성동구 송정동" , runningTime: "500분", review: "두줄까지 작성됩니다. 두줄 넘어가면 좌/우 여백 유지하면서 좌측 정렬로 줄내림되면서 ... 처리 됩니다.두줄까지 작성됩니다. 두줄 넘어가면 좌/우 여백 유지하면서 좌측 정렬로 줄내림되면서 ... 처리 됩니다.", runningDate: "12월 31일 토요일 오후 6~9시", recommendedTags: ["1","2"], secureTags: ["0","1","2"], files: nil)
-        let secondData = Route(user: User(userId: "경준", nickname: "경준"),routeName: "한강 잠실 러닝길",distance: 300,arrayOfPos: [CLLocationCoordinate2D(latitude: 37.2759, longitude: 127.1488), CLLocationCoordinate2D(latitude: 37.2765, longitude: 127.1493), CLLocationCoordinate2D(latitude: 37.2771, longitude: 127.1502)], location:"기흥구 동백동" , runningTime: "320분", review: "예시 데이터입니다. 여기 러닝 코스 아주 괜찮습니다. 붕어빵 가게도 있습니다. 중간에 ㅕ편의점도 있어요 ! 경치가 좋아요~ 고양이가 많습니당", runningDate: "12월 30일 일요일 오후 2~3시", recommendedTags: ["0","1","2"], secureTags: ["0","1"], files: nil)
-        
-        let thirdData = Route(user: User(userId: "경준", nickname: "경준"),routeName: "동백 호수공원",distance: 200,arrayOfPos: [CLLocationCoordinate2D(latitude: 37.2785, longitude: 127.1452),CLLocationCoordinate2D(latitude: 37.2779, longitude: 127.1452),CLLocationCoordinate2D(latitude: 37.2767, longitude: 127.1444)], location:"기흥구 언동로" , runningTime: "200분", review: "나무가 풍성한 동백 호수공원을 달려보아요", runningDate: "12월 30일 일요일 오후 2~3시", recommendedTags: ["0","1","2"], secureTags: ["0","1", "2", "3", "4"], files:[UIImage(named: "test1")!, UIImage(named:"test2")!, UIImage(named:"test3")!, UIImage(named:"test4")!])
-        
-        
-        routeData.append(firstData)
-        routeData.append(secondData)
-        routeData.append(thirdData)
-    }
 
 }
 // MARK: - Layouts


### PR DESCRIPTION
1. registerButtonTapped 및 경로 따라가기 뷰에 인디케이터 삽입하였습니다. API 호출 success 및 failure 분기처리 후 hidden처리하였습니다.
2. 메인루트 모델 정의했습니다. 현재 `/running-route/main/{id}`에는 arrayOfPos가 내려오고 있지 않아 기석님께 관련하여 확인 부탁드렸습니다. 
3. `registerButtonTapped`에서 pngData 정제 및 압축, base64 인코딩 후 POST요청 보내는 코드 추가해두었습니다. 
4. 모델 추후 수정될 예정이므로 코드 참고만 해주세요!
